### PR TITLE
Update idle_and_physics_processing.rst: Specify that processing happens in *tree order*

### DIFF
--- a/tutorials/scripting/idle_and_physics_processing.rst
+++ b/tutorials/scripting/idle_and_physics_processing.rst
@@ -9,6 +9,8 @@ class to do so: :ref:`Node._process() <class_Node_private_method__process>` and
 :ref:`Node._physics_process() <class_Node_private_method__physics_process>`. If you
 define either or both in a script, the engine will call them automatically.
 
+Processing happens in tree order, or top to bottom as seen in the editor (also known as pre-order traversal). This means that if the node has children, they will be processed after the parent node.
+
 There are two types of processing available to you:
 
 1. **Idle processing** allows you to run code that updates a node every frame,


### PR DESCRIPTION
Specify that processing happens in *tree order*.

It was quite hard to find out in which order processing is called. Someone linked me to https://docs.godotengine.org/en/4.3/tutorials/scripting/scene_tree.html#tree-order which explains it, but it would be great to also have this information directly here.

For comparison, for ``ready`` it's clearly articulated that it's called in reverse, that is, first the children then the parent.

I'd like to also add this information to the API docs of [``Node``](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-private-method-process). Here again, it's spelled out for ``ready`` but omitted for ``process``.

I assume that would need to be changed in the source code repository?

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
